### PR TITLE
Fix typo in QjsLocalReference.cc

### DIFF
--- a/backend/QuickJs/QjsLocalReference.cc
+++ b/backend/QuickJs/QjsLocalReference.cc
@@ -209,7 +209,7 @@ bool Local<Value>::operator==(const script::Local<script::Value>& other) const {
   auto context = engine.context_;
 #ifdef QUICK_JS_HAS_SCRIPTX_PATCH
   return JS_StrictEqual(context, val_, qjs_interop::peekLocal(other));
-#elif
+#else
   auto fun = qjs_interop::makeLocal<Function>(
       qjs_backend::dupValue(engine.helperFunctionStrictEqual_, context));
   return fun.call({}, *this, other).asBoolean().value();


### PR DESCRIPTION
I got a compiler error when trying to build:

```
QjsLocalReference.cc:212:6: error: expected value in expression
#elif
     ^
```

changing the `#elif` to an `#else` fixes it.
