### PR TITLE
QuickJs support ESM and add engine->loadFile

### DIFF
--- a/backend/JavaScriptCore/JscEngine.cc
+++ b/backend/JavaScriptCore/JscEngine.cc
@@ -19,6 +19,7 @@
 #include "../../src/Native.hpp"
 #include "JscEngine.hpp"
 #include "JscHelper.h"
+#include "../../src/utils/Helper.hpp"
 
 namespace script::jsc_backend {
 
@@ -175,6 +176,27 @@ script::Local<script::Value> JscEngine::eval(const script::Local<script::String>
 
 script::Local<script::Value> JscEngine::eval(const script::Local<script::String>& script) {
   return eval(script, {});
+}
+
+Local<Value> JscEngine::loadFile(const Local<String>& scriptFile) {
+  if(scriptFile.toString().empty())
+    throw Exception("script file no found");
+  Local<Value> content = internal::readAllFileContent(scriptFile);
+  if(content.isNull())
+    throw Exception("can't load script file");
+
+  std::string sourceFilePath = scriptFile.toString();
+  std::size_t pathSymbol = sourceFilePath.rfind("/");
+  if(pathSymbol != -1)
+    sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  else
+  {
+    pathSymbol = sourceFilePath.rfind("\\");
+    if(pathSymbol != -1)
+      sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  }
+  Local<String> sourceFileName = String::newString(sourceFilePath);
+  return eval(content.asString(), sourceFileName);
 }
 
 std::shared_ptr<utils::MessageQueue> JscEngine::messageQueue() { return messageQueue_; }

--- a/backend/JavaScriptCore/JscEngine.h
+++ b/backend/JavaScriptCore/JscEngine.h
@@ -86,6 +86,8 @@ class JscEngine : public ::script::ScriptEngine {
   Local<Value> eval(const Local<String>& script) override;
   using ScriptEngine::eval;
 
+  Local<Value> loadFile(const Local<String>& scriptFile) override;
+
   std::shared_ptr<utils::MessageQueue> messageQueue() override;
 
   void gc() override;

--- a/backend/Lua/LuaEngine.cc
+++ b/backend/Lua/LuaEngine.cc
@@ -28,6 +28,7 @@
 #include "LuaHelper.hpp"
 #include "LuaReference.hpp"
 #include "LuaScope.hpp"
+#include "../../src/utils/Helper.hpp"
 
 // ref https://www.lua.org/manual/5.1/manual.html
 // https://www.lua.org/wshop14/Zykov.pdf
@@ -257,6 +258,27 @@ Local<Value> LuaEngine::eval(const Local<String>& script, const Local<Value>& so
   }
 
   return lua_backend::callFunction({}, {}, 0, nullptr);
+}
+
+Local<Value> LuaEngine::loadFile(const Local<String>& scriptFile) {
+  if(scriptFile.toString().empty())
+    throw Exception("script file no found");
+  Local<Value> content = internal::readAllFileContent(scriptFile);
+  if(content.isNull())
+    throw Exception("can't load script file");
+
+  std::string sourceFilePath = scriptFile.toString();
+  std::size_t pathSymbol = sourceFilePath.rfind("/");
+  if(pathSymbol != -1)
+    sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  else
+  {
+    pathSymbol = sourceFilePath.rfind("\\");
+    if(pathSymbol != -1)
+      sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  }
+  Local<String> sourceFileName = String::newString(sourceFilePath);
+  return eval(content.asString(), sourceFileName);
 }
 
 Arguments LuaEngine::makeArguments(LuaEngine* engine, int stackBase, size_t paramCount,

--- a/backend/Lua/LuaEngine.h
+++ b/backend/Lua/LuaEngine.h
@@ -77,6 +77,8 @@ class LuaEngine : public ScriptEngine {
   Local<Value> eval(const Local<String>& script) override;
   using ScriptEngine::eval;
 
+  Local<Value> loadFile(const Local<String>& scriptFile) override;
+
   std::shared_ptr<utils::MessageQueue> messageQueue() override;
 
   void gc() override;

--- a/backend/QuickJs/QjsEngine.cc
+++ b/backend/QuickJs/QjsEngine.cc
@@ -17,6 +17,7 @@
 
 #include "QjsEngine.h"
 #include <ScriptX/ScriptX.h>
+#include "../../src/utils/Helper.hpp"
 
 namespace script::qjs_backend {
 
@@ -266,6 +267,27 @@ Local<Value> QjsEngine::eval(const Local<String>& script, const Local<Value>& so
   scheduleTick();
 
   return Local<Value>(ret);
+}
+
+Local<Value> QjsEngine::loadFile(const Local<String>& scriptFile) {
+  if(scriptFile.toString().empty())
+    throw Exception("script file no found");
+  Local<Value> content = internal::readAllFileContent(scriptFile);
+  if(content.isNull())
+    throw Exception("can't load script file");
+
+  std::string sourceFilePath = scriptFile.toString();
+  std::size_t pathSymbol = sourceFilePath.rfind("/");
+  if(pathSymbol != -1)
+    sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  else
+  {
+    pathSymbol = sourceFilePath.rfind("\\");
+    if(pathSymbol != -1)
+      sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  }
+  Local<String> sourceFileName = String::newString(sourceFilePath);
+  return eval(content.asString(), sourceFileName);
 }
 
 std::shared_ptr<utils::MessageQueue> QjsEngine::messageQueue() { return queue_; }

--- a/backend/QuickJs/QjsEngine.cc
+++ b/backend/QuickJs/QjsEngine.cc
@@ -95,6 +95,9 @@ QjsEngine::QjsEngine(std::shared_ptr<utils::MessageQueue> queue, const QjsFactor
   }
 
   initEngineResource();
+
+  /* set default loader for ES6 modules */
+  JS_SetModuleLoaderFunc(runtime_, NULL, js_module_loader, NULL);  
 }
 
 void QjsEngine::initEngineResource() {
@@ -270,12 +273,15 @@ Local<Value> QjsEngine::eval(const Local<String>& script, const Local<Value>& so
 }
 
 Local<Value> QjsEngine::loadFile(const Local<String>& scriptFile) {
+  Tracer trace(this, "QjsEngine::loadFile");
+
   if(scriptFile.toString().empty())
     throw Exception("script file no found");
   Local<Value> content = internal::readAllFileContent(scriptFile);
   if(content.isNull())
     throw Exception("can't load script file");
 
+  // get source file name
   std::string sourceFilePath = scriptFile.toString();
   std::size_t pathSymbol = sourceFilePath.rfind("/");
   if(pathSymbol != -1)
@@ -287,7 +293,16 @@ Local<Value> QjsEngine::loadFile(const Local<String>& scriptFile) {
       sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
   }
   Local<String> sourceFileName = String::newString(sourceFilePath);
-  return eval(content.asString(), sourceFileName);
+
+  StringHolder contentStr(content.asString());
+  StringHolder fileNameStr(sourceFileName);
+  JSValue ret = JS_Eval(context_, contentStr.c_str(), contentStr.length(), fileNameStr.c_str(),
+      JS_EVAL_TYPE_MODULE);
+    
+  qjs_backend::checkException(ret);
+  scheduleTick();
+
+  return Local<Value>(ret);
 }
 
 std::shared_ptr<utils::MessageQueue> QjsEngine::messageQueue() { return queue_; }

--- a/backend/QuickJs/QjsEngine.h
+++ b/backend/QuickJs/QjsEngine.h
@@ -94,6 +94,8 @@ class QjsEngine : public ScriptEngine {
   Local<Value> eval(const Local<String>& script) override;
   using ScriptEngine::eval;
 
+  Local<Value> loadFile(const Local<String>& scriptFile) override;
+
   std::shared_ptr<utils::MessageQueue> messageQueue() override;
 
   void gc() override;

--- a/backend/QuickJs/QjsHelper.h
+++ b/backend/QuickJs/QjsHelper.h
@@ -21,6 +21,7 @@
 
 SCRIPTX_BEGIN_INCLUDE_LIBRARY
 #include <quickjs.h>
+#include <quickjs-libc.h>
 SCRIPTX_END_INCLUDE_LIBRARY
 
 namespace script::qjs_backend {

--- a/backend/V8/V8Engine.cc
+++ b/backend/V8/V8Engine.cc
@@ -19,6 +19,7 @@
 #include <ScriptX/ScriptX.h>
 #include <cassert>
 #include <memory>
+#include "../../src/utils/Helper.hpp"
 
 namespace script::v8_backend {
 
@@ -173,6 +174,27 @@ Local<Value> V8Engine::eval(const Local<String>& script, const Local<String>& so
 }
 
 Local<Value> V8Engine::eval(const Local<String>& script) { return eval(script, {}); }
+
+Local<Value> V8Engine::loadFile(const Local<String>& scriptFile) {
+  if(scriptFile.toString().empty())
+    throw Exception("script file no found");
+  Local<Value> content = internal::readAllFileContent(scriptFile);
+  if(content.isNull())
+    throw Exception("can't load script file");
+
+  std::string sourceFilePath = scriptFile.toString();
+  std::size_t pathSymbol = sourceFilePath.rfind("/");
+  if(pathSymbol != -1)
+    sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  else
+  {
+    pathSymbol = sourceFilePath.rfind("\\");
+    if(pathSymbol != -1)
+      sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  }
+  Local<String> sourceFileName = String::newString(sourceFilePath);
+  return eval(content.asString(), sourceFileName);
+}
 
 void V8Engine::registerNativeClassStatic(v8::Local<v8::FunctionTemplate> funcT,
                                          const internal::StaticDefine* staticDefine) {

--- a/backend/V8/V8Engine.h
+++ b/backend/V8/V8Engine.h
@@ -115,6 +115,8 @@ class V8Engine : public ::script::ScriptEngine {
   Local<Value> eval(const Local<String>& script) override;
   using ScriptEngine::eval;
 
+  Local<Value> loadFile(const Local<String>& scriptFile) override;
+
   /**
    * Create a new V8 Engine that share the same isolate, but with different context.
    * Caller own the returned pointer, and the returned instance

--- a/backend/WebAssembly/WasmEngine.cc
+++ b/backend/WebAssembly/WasmEngine.cc
@@ -23,6 +23,7 @@
 #include "WasmNative.hpp"
 #include "WasmReference.hpp"
 #include "WasmScope.hpp"
+#include "../../src/utils/Helper.hpp"
 
 namespace script::wasm_backend {
 
@@ -74,6 +75,27 @@ Local<Value> WasmEngine::eval(const Local<String>& script, const Local<Value>& s
   Tracer trace(this, "WasmEngine::eval");
   auto retIndex = evaluateJavaScriptCode(script.val_, sourceFile.val_);
   return Local<Value>(retIndex);
+}
+
+Local<Value> WasmEngine::loadFile(const Local<String>& scriptFile) {
+  if(scriptFile.toString().empty())
+    throw Exception("script file no found");
+  Local<Value> content = internal::readAllFileContent(scriptFile);
+  if(content.isNull())
+    throw Exception("can't load script file");
+
+  std::string sourceFilePath = scriptFile.toString();
+  std::size_t pathSymbol = sourceFilePath.rfind("/");
+  if(pathSymbol != -1)
+    sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  else
+  {
+    pathSymbol = sourceFilePath.rfind("\\");
+    if(pathSymbol != -1)
+      sourceFilePath = sourceFilePath.substr(pathSymbol + 1);
+  }
+  Local<String> sourceFileName = String::newString(sourceFilePath);
+  return eval(content.asString(), sourceFileName);
 }
 
 std::shared_ptr<utils::MessageQueue> WasmEngine::messageQueue() { return messageQueue_; }

--- a/backend/WebAssembly/WasmEngine.h
+++ b/backend/WebAssembly/WasmEngine.h
@@ -74,6 +74,8 @@ class WasmEngine : public ScriptEngine {
   Local<Value> eval(const Local<String>& script) override;
   using ScriptEngine::eval;
 
+  Local<Value> loadFile(const Local<String>& scriptFile) override;
+
   std::shared_ptr<utils::MessageQueue> messageQueue() override;
 
   void gc() override;

--- a/src/Engine.h
+++ b/src/Engine.h
@@ -121,6 +121,17 @@ class ScriptEngine {
   }
 
   /**
+   * @param scriptFile path of script file to load
+   * @return evaluate result
+   */
+  virtual Local<Value> loadFile(const Local<String>& scriptFile) = 0;
+
+  template <typename T = std::string, StringLikeConcept(T)>
+  Local<Value> loadFile(T&& scriptFileStringLike) {
+    return loadFile(String::newString(std::forward<T>(scriptFileStringLike)));
+  }
+
+  /**
    * register a native class definition (constructor & property & function) to script.
    * @tparam T a subclass of the NativeClass, which implements all the Script-Native method in cpp.
    * (can be void if no instance is required).

--- a/src/utils/Helper.cc
+++ b/src/utils/Helper.cc
@@ -18,6 +18,7 @@
 #include <ScriptX/ScriptX.h>
 
 #include <utility>
+#include <fstream>
 
 namespace script::internal {
 
@@ -54,6 +55,19 @@ Local<Value> getNamespaceObject(ScriptEngine* engine, const std::string_view& na
     }
   }
   return nameSpaceObj;
+}
+
+Local<Value> readAllFileContent(const Local<String>& scriptFile)
+{
+  std::ifstream fRead;
+  fRead.open(scriptFile.toString(), std::ios_base::in);
+  if (!fRead.is_open()) {
+      return Local<Value>();
+  }
+  std::string data((std::istreambuf_iterator<char>(fRead)),
+                    std::istreambuf_iterator<char>());
+  fRead.close();
+  return String::newString(std::move(data)).asValue();
 }
 
 }  // namespace script::internal

--- a/src/utils/Helper.hpp
+++ b/src/utils/Helper.hpp
@@ -55,4 +55,6 @@ void withNArray(size_t N, FN&& fn) {
 
 Local<Value> getNamespaceObject(ScriptEngine* engine, const std::string_view& nameSpace,
                                 Local<Value> rootNs = {});
+
+Local<Value> readAllFileContent(const Local<String>& scriptFile);
 }  // namespace script::internal


### PR DESCRIPTION
RT，使QuickJS可以正常使用ESM的import和export机制。默认的JS_EVAL_GLOBAL不支持ESM，此处修改为JS_EVAL_MODULE，并加载了qjs-libc默认提供的es6 module loader. 经过测试可以完全正常工作。

其次，JS_EVAL_MODULE的行为与JS_EVAL_GLOBAL不同。JS_EVAL_GLOBAL在执行多行JS代码时，会将最后一行代码的返回值作为整个eval调用的返回值，而JS_EVAL_MODULE不会这样。这个也可以理解，因为module是针对文件调用而设计的。
（同样的，python backend的eval和文件加载也具有和上述完全一样的行为）

因此，为了解决这两种module eval与普通eval语义不同的问题，又联想到 #89 issue，为各引擎增加了一个loadFile函数，针对loadFile的特殊情况进行处理，与普通的eval分开。
不需要特殊处理的引擎的loadFile将读取文件后直接调用eval。